### PR TITLE
Snakemake permission issue

### DIFF
--- a/2_generate_manifest.py
+++ b/2_generate_manifest.py
@@ -16,12 +16,12 @@ import yaml
 
 def main():
     # Load config
-    with open('/coloc/configs/config.yaml') as config_input:
+    with open('configs/config.yaml') as config_input:
         config = yaml.load(config_input, Loader=yaml.FullLoader)
 
     # Parse args
     in_overlap_table = glob('/data/overlap_table/*.json.gz')[0]
-    out_manifest = '/coloc/configs/manifest.json.gz'
+    out_manifest = 'configs/manifest.json.gz'
     overlap_prop_threshold = 0.01
     max_credset_threshold = None
 

--- a/3_make_commands.py
+++ b/3_make_commands.py
@@ -16,7 +16,7 @@ def main():
 
     # Args
     args = parse_args()
-    in_manifest = '/coloc/configs/manifest.json.gz'
+    in_manifest = 'configs/manifest.json.gz'
     out_todo = '/data/commands_todo.txt.gz'
     out_done = '/data/commands_done.txt.gz'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,17 @@
 FROM r-base:3.6.1
 
-ENV credset_dir='/data/credset'
-ENV DEBIAN_FRONTEND=noninteractive
+# Create non-root user 
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -g $GID -o otg
+RUN useradd -m -u $UID -g $GID -o -s /bin/bash otg
 
+# Do everything that requires root user
 # Install OpenJDK-8
 RUN apt-get update && \
     apt-get remove -y -o APT::Immediate-Configure=0 libgcc1 && \
     apt-get install -y ant && \
     apt-get clean;
-
-# Conda and the envirounment dependencies
-RUN mkdir /conda
-RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /conda/miniconda.sh
-RUN bash /conda/miniconda.sh -b -p /conda/miniconda
-ENV PATH="/conda/miniconda/bin:${PATH}"
-COPY ./environment.yaml /coloc/
-WORKDIR /coloc
-RUN conda env create -n coloc --file environment.yaml
 
 # Fix certificate issues
 RUN apt-get update && \
@@ -24,25 +19,16 @@ RUN apt-get update && \
     apt-get clean && \
     update-ca-certificates -f;
 
-# Setup JAVA_HOME -- useful for docker commandline
-ENV JAVA_HOME='/conda/miniconda/envs/coloc'
-
-# Google Cloud SDK
+# curl
 RUN apt-get install -y curl
-RUN curl https://sdk.cloud.google.com | bash
-
-# Default command
-CMD ["/bin/bash"]
 
 # Install parallel
 RUN apt install -yf parallel
 
-# Install GCTA
+# download gcta
 RUN apt-get install unzip
 RUN wget https://cnsgenomics.com/software/gcta/bin/gcta_1.92.3beta3.zip -P /software/gcta
-RUN unzip /software/gcta/gcta_1.92.3beta3.zip -d /software/gcta
-RUN rm /software/gcta/gcta_1.92.3beta3.zip
-ENV PATH="/software/gcta/gcta_1.92.3beta3:${PATH}"
+RUN chown -R otg:otg /software/gcta
 
 # Install R packages
 RUN apt-get -y install libxml2-dev libssl-dev libcurl4-openssl-dev
@@ -50,8 +36,44 @@ RUN Rscript -e "install.packages('BiocManager', dependencies=TRUE, repos='http:/
 RUN R -e "install.packages('coloc', dependencies=TRUE, repos='http://cran.rstudio.com/')"
 RUN R -e "install.packages('tidyverse', dependencies=TRUE, repos='http://cran.rstudio.com/')"
 
+# switch to otg user
+USER otg
+
+ENV credset_dir='/data/credset'
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Conda and the envirounment dependencies
+COPY ./environment.yaml /home/otg/coloc/
+WORKDIR /home/otg/coloc
+RUN mkdir /home/otg/conda
+RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /home/otg/conda/miniconda.sh
+RUN bash /home/otg/conda/miniconda.sh -b -p /home/otg/conda/miniconda
+ENV PATH="/home/otg/conda/miniconda/bin:${PATH}"
+RUN conda env create -n coloc --file environment.yaml
+
+# Setup JAVA_HOME -- useful for docker commandline
+ENV JAVA_HOME='/home/otg/conda/miniconda/envs/coloc'
+
+# Default command
+CMD ["/bin/bash"]
+
+# Install GCTA
+RUN unzip /software/gcta/gcta_1.92.3beta3.zip -d /software/gcta
+RUN rm /software/gcta/gcta_1.92.3beta3.zip
+ENV PATH="/software/gcta/gcta_1.92.3beta3:${PATH}"
+
+# Google Cloud SDK
+RUN curl https://sdk.cloud.google.com | bash
+
 # Copy the v2d project
-COPY ./ /coloc
+COPY ./ /home/otg/coloc
+
+# Make all files in coloc and data owned by the non-root user
+USER root
+RUN chown -R otg:otg /home/otg/coloc
+RUN mkdir /data
+RUN chown -R otg:otg /data
+USER otg
 
 # Activate coloc environment
-ENV PATH /conda/miniconda/envs/coloc/bin:$PATH
+ENV PATH /home/otg/conda/miniconda/envs/coloc/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM r-base:3.6.1
 
 # Create non-root user 
-ARG UID=1000
-ARG GID=1000
+ARG UID
+ARG GID
 RUN groupadd -g $GID -o otg
 RUN useradd -m -u $UID -g $GID -o -s /bin/bash otg
 


### PR DESCRIPTION
added non-root user to docker image.
Note that in this case the uid and gid are specified for the user via the build arguments.
when mounting a file/folder, they keep the same uid:gid that they have on the host, in my case 1000:1000. for some reason this docker image already has a user with uid:gid 1000:1000 named docker... so the new user is assigned uid:gid 1001:1001 if one does not specify them. the result would be a otg user 1001:1001 that does not have acces to mounted folders with 1000:1000.

in case of the finemapping image, there is no user with 1000:1000 so the new user gets uid:gid 1000:1000 assigned, this is the same as on my local machine so no problems.
however I think it might be better practice to also create the finemapping image with a set uid:gid via build arg to make sure the user in the docker container has the same uid:gid as the user that is running snakemake since there is of course no guarantee that the uid:gid on a client infrastructure is 1000:1000
